### PR TITLE
Add Adaptive NPGM optimizers and updated run.py

### DIFF
--- a/pytorch/optimizer_adaptive_npgm.py
+++ b/pytorch/optimizer_adaptive_npgm.py
@@ -1,0 +1,108 @@
+import torch
+import numpy as np
+from torch.optim.optimizer import Optimizer, required
+
+class AdsgdAdaptiveNPGM(Optimizer):
+    """
+    Adaptive SGD optimizer implementing the Adaptive NPGM logic from Algorithm 1.
+    Scaling factor sₖ = arsinh(||gₖ||)/||gₖ||, adaptive rule for gammaₖ₊₁.
+    """
+    def __init__(self, params, lr=1e-2, weight_decay=0):
+        if lr < 0.0:
+            raise ValueError(f"Invalid initial learning rate: {lr}")
+        if weight_decay < 0.0:
+            raise ValueError(f"Invalid weight_decay value: {weight_decay}")
+
+        defaults = dict(lr=lr, weight_decay=weight_decay)
+        super(AdsgdAdaptiveNPGM, self).__init__(params, defaults)
+
+    def __setstate__(self, state):
+        super(AdsgdAdaptiveNPGM, self).__setstate__(state)
+        for group in self.param_groups:
+            group.setdefault('lr', 1e-2)
+            group.setdefault('weight_decay', 0)
+
+    def compute_dif_norms(self, prev_optimizer):
+        for group, prev_group in zip(self.param_groups, prev_optimizer.param_groups):
+            grad_diff_sq = 0.0
+            param_diff_sq = 0.0
+            for p, prev_p in zip(group['params'], prev_group['params']):
+                if p.grad is None or prev_p.grad is None:
+                    continue
+                grad_diff_sq += (p.grad.data - prev_p.grad.data).norm().item()**2
+                param_diff_sq += (p.data - prev_p.data).norm().item()**2
+            group['grad_diff_norm'] = np.sqrt(grad_diff_sq)
+            group['param_diff_norm'] = np.sqrt(param_diff_sq)
+
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            loss = closure()
+
+        for group in self.param_groups:
+            weight_decay = group['weight_decay']
+
+            for p in group['params']:
+                if p.grad is None:
+                    continue
+
+                grad = p.grad.data
+                state = self.state[p]
+
+                # Initialization
+                if len(state) == 0:
+                    gamma = group['lr']
+                    norm_g = grad.norm().item()
+                    scaling = np.arcsinh(norm_g) / norm_g if norm_g > 0 else 0.0
+                    scaled_grad = scaling * grad
+
+                    state['step'] = 0
+                    state['gamma'] = gamma
+                    state['gamma_prev'] = gamma
+                    state['scaling_old'] = scaling
+                    state['scaled_grad_old'] = scaled_grad.clone()
+                    state['norm_grad_old'] = norm_g
+                    state['x_old'] = p.data.clone()
+
+                    if weight_decay != 0:
+                        grad.add_(weight_decay, p.data)
+                    p.data.add_(scaled_grad, alpha=-gamma)
+                    continue
+
+                # Step info
+                gamma = state['gamma']
+                gamma_prev = state['gamma_prev']
+                scaling_old = state['scaling_old']
+                scaled_grad_old = state['scaled_grad_old']
+                norm_grad_old = state['norm_grad_old']
+                x_old = state['x_old']
+
+                # Compute new scaled gradient
+                norm_g = grad.norm().item()
+                scaling = np.arcsinh(norm_g) / norm_g if norm_g > 0 else 0.0
+                scaled_grad = scaling * grad
+
+                # Estimate curvature
+                delta_g = scaled_grad - scaled_grad_old
+                delta_x = p.data - x_old
+                Lk = delta_g.norm().item() / (delta_x.norm().item() + 1e-12)
+
+                # Adaptive rule for gamma
+                tau = gamma * (scaling_old / scaling) * (norm_g / norm_grad_old) * (1 + gamma / gamma_prev)
+                gamma_new = min(tau, 1.0 / (2 * Lk))
+
+                # Apply update
+                if weight_decay != 0:
+                    grad.add_(weight_decay, p.data)
+                p.data.add_(scaled_grad, alpha=-gamma_new)
+
+                # Update state
+                state['step'] += 1
+                state['gamma_prev'] = gamma
+                state['gamma'] = gamma_new
+                state['scaling_old'] = scaling
+                state['scaled_grad_old'] = scaled_grad.clone()
+                state['norm_grad_old'] = norm_g
+                state['x_old'] = p.data.clone()
+
+        return loss

--- a/pytorch/optimizer_adaptive_npgm2.py
+++ b/pytorch/optimizer_adaptive_npgm2.py
@@ -1,0 +1,114 @@
+import torch
+import numpy as np
+from torch.optim.optimizer import Optimizer, required
+
+class AdsgdAdaptiveNPGM(Optimizer):
+    """
+    Adaptive SGD optimizer implementing the Adaptive NPGM logic from Algorithm 1.
+    Scaling factor sₖ = arsinh(||gₖ||)/||gₖ||, adaptive rule for gammaₖ₊₁.
+    """
+    def __init__(self, params, lr=1e-2, weight_decay=0):
+        if lr < 0.0:
+            raise ValueError(f"Invalid initial learning rate: {lr}")
+        if weight_decay < 0.0:
+            raise ValueError(f"Invalid weight_decay value: {weight_decay}")
+
+        defaults = dict(lr=lr, weight_decay=weight_decay)
+        super(AdsgdAdaptiveNPGM, self).__init__(params, defaults)
+
+    def __setstate__(self, state):
+        super(AdsgdAdaptiveNPGM, self).__setstate__(state)
+        for group in self.param_groups:
+            group.setdefault('lr', 1e-2)
+            group.setdefault('weight_decay', 0)
+
+    def compute_dif_norms(self, prev_optimizer):
+        for group, prev_group in zip(self.param_groups, prev_optimizer.param_groups):
+            grad_diff_sq = 0.0
+            param_diff_sq = 0.0
+            for p, prev_p in zip(group['params'], prev_group['params']):
+                if p.grad is None or prev_p.grad is None:
+                    continue
+                grad_diff_sq += (p.grad.data - prev_p.grad.data).norm().item()**2
+                param_diff_sq += (p.data - prev_p.data).norm().item()**2
+            group['grad_diff_norm'] = np.sqrt(grad_diff_sq)
+            group['param_diff_norm'] = np.sqrt(param_diff_sq)
+
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            loss = closure()
+
+        for group in self.param_groups:
+            weight_decay = group['weight_decay']
+
+            for p in group['params']:
+                if p.grad is None:
+                    continue
+
+                grad = p.grad.data
+                state = self.state[p]
+
+                # Initialization
+                if len(state) == 0:
+                    gamma = group['lr']
+                    norm_g = grad.norm().item()
+                    scaling = np.arcsinh(norm_g) / norm_g if norm_g > 0 else 0.0
+                    scaled_grad = scaling * grad
+
+                    state['step'] = 0
+                    state['gamma'] = gamma
+                    state['gamma_prev'] = gamma
+                    state['scaling_old'] = scaling
+                    state['scaled_grad_old'] = scaled_grad.clone()
+                    state['norm_grad_old'] = norm_g
+                    state['x_old'] = p.data.clone()
+
+                    # Weight decay outside grad graph
+                    if weight_decay != 0:
+                        grad = grad.add(p.data, alpha=weight_decay)
+                    # Parameter update without tracking in autograd
+                    with torch.no_grad():
+                        p.data.add_(scaled_grad, alpha=-gamma)
+                    continue
+
+                # Load history
+                gamma = state['gamma']
+                gamma_prev = state['gamma_prev']
+                scaling_old = state['scaling_old']
+                scaled_grad_old = state['scaled_grad_old']
+                norm_grad_old = state['norm_grad_old']
+                x_old = state['x_old']
+
+                # Compute new scaled gradient
+                norm_g = grad.norm().item()
+                scaling = np.arcsinh(norm_g) / norm_g if norm_g > 0 else 0.0
+                scaled_grad = scaling * grad
+
+                # Estimate curvature
+                delta_g = scaled_grad - scaled_grad_old
+                delta_x = p.data - x_old
+                Lk = delta_g.norm().item() / (delta_x.norm().item() + 1e-12)
+
+                # Adaptive rule for gamma
+                tau = gamma * (scaling_old / scaling) * (norm_g / norm_grad_old) * (1 + gamma / gamma_prev)
+                gamma_new = min(tau, 1.0 / (2 * Lk))
+
+                # Effective gradient for weight decay
+                if weight_decay != 0:
+                    grad = grad.add(p.data, alpha=weight_decay)
+
+                # Parameter update with no_grad
+                with torch.no_grad():
+                    p.data.add_(scaled_grad, alpha=-gamma_new)
+
+                # Update state
+                state['step'] += 1
+                state['gamma_prev'] = gamma
+                state['gamma'] = gamma_new
+                state['scaling_old'] = scaling
+                state['scaled_grad_old'] = scaled_grad.clone()
+                state['norm_grad_old'] = norm_g
+                state['x_old'] = p.data.clone()
+
+        return loss

--- a/pytorch/run.py
+++ b/pytorch/run.py
@@ -5,7 +5,11 @@ import time
 
 # from optimizer import Adsgd   την εχω βαλει σε comment
 # from optimizer_adgrad import AdsgdAdGrad
-from optimizer_adgrad_nesterov import AdsgdAdGradNesterov
+# from optimizer_adgrad_nesterov import AdsgdAdGradNesterov
+from optimizer_adaptive_npgm import AdsgdAdaptiveNPGM
+# from optimizer_adaptive_npgm2 import AdsgdAdaptiveNPGM
+
+
 
 from utils import load_data, accuracy_and_loss, save_results, seed_everything
 
@@ -43,14 +47,16 @@ def run_adgd(net, n_epoch=2, amplifier=0.02, damping=1, weight_decay=0, eps=1e-8
     #     tau_rule='original'   #(για το  k/(k+3) βαζω tau_rule='mod')
     # )
     initial_lr = 1e-2
-    optimizer = AdsgdAdGradNesterov(net.parameters(),
-                                    lr=initial_lr,
-                                    weight_decay=weight_decay,
-                                    tau_rule='original')  # ή 'mod'
-    prev_optimizer = AdsgdAdGradNesterov(prev_net.parameters(),
-                                         lr=initial_lr,
-                                         weight_decay=weight_decay,
-                                         tau_rule='original')
+    # optimizer = AdsgdAdGradNesterov(net.parameters(),
+    #                                 lr=initial_lr,
+    #                                 weight_decay=weight_decay,
+    #                                 tau_rule='original')  # ή 'mod'
+    # prev_optimizer = AdsgdAdGradNesterov(prev_net.parameters(),
+    #                                      lr=initial_lr,
+    #                                      weight_decay=weight_decay,
+    #                                      tau_rule='original')
+    optimizer = AdsgdAdaptiveNPGM(net.parameters(), lr=initial_lr, weight_decay=weight_decay)
+    prev_optimizer = AdsgdAdaptiveNPGM(prev_net.parameters(), lr=initial_lr, weight_decay=weight_decay)
 
     for epoch in range(n_epoch):  # loop over the dataset multiple times
 


### PR DESCRIPTION
### Overview
Add `AdsgdAdaptiveNPGM` and `AdsgdAdaptiveNPGM2` optimizers.
 Update `run.py` example to import and use the new optimizers, with logging of loss, lr, and elapsed time.

### Usage
```python
from optimizer_adaptive_npgm import AdsgdAdaptiveNPGM
optimizer = AdsgdAdaptiveNPGM(net.parameters(), lr=1e-2, weight_decay=0)
